### PR TITLE
Save the desired package manager in the `user-settings.json`

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -82,6 +82,7 @@ $injector.requireCommand(["setup|cloud", "cloud|setup"], "./commands/setup");
 $injector.requirePublic("packageManager", "./package-manager");
 $injector.requirePublic("npm", "./node-package-manager");
 $injector.requirePublic("yarn", "./yarn-package-manager");
+$injector.requireCommand("package-manager|set", "./commands/package-manager-set");
 
 $injector.require("npmInstallationManager", "./npm-installation-manager");
 $injector.require("dynamicHelpProvider", "./dynamic-help-provider");

--- a/lib/common/commands/package-manager-set.ts
+++ b/lib/common/commands/package-manager-set.ts
@@ -1,0 +1,20 @@
+
+export class PackageManagerCommand implements ICommand {
+
+	constructor(private $userSettingsService: IUserSettingsService,
+		private $errors: IErrors,
+		private $stringParameter: ICommandParameter) { }
+
+	public allowedParameters: ICommandParameter[] = [this.$stringParameter];
+
+	public execute(args: string[]): Promise<void> {
+		if (args[0] === 'yarn' ) {
+			return this.$userSettingsService.saveSetting("packageManager", "yarn");
+		} else if ( args[0] === 'npm') {
+			return this.$userSettingsService.saveSetting("packageManager", "npm");
+		}
+		return this.$errors.fail(`${args[0]} is not a valid package manager. Only yarn or npm are supported.`);
+	}
+}
+
+$injector.registerCommand("package-manager|set", PackageManagerCommand);

--- a/lib/package-manager.ts
+++ b/lib/package-manager.ts
@@ -6,9 +6,10 @@ export class PackageManager implements INodePackageManager {
 	constructor(
 		private $npm: INodePackageManager,
 		private $options: IOptions,
-		private $yarn: INodePackageManager
+		private $yarn: INodePackageManager,
+		private $userSettingsService: IUserSettingsService
 	) {
-		this.packageManager = this._determinePackageManager();
+		this._determinePackageManager();
 	}
 	@exported("packageManager")
 	public install(packageName: string, pathToSave: string, config: INodePackageManagerInstallOptions): Promise<INpmInstallResultInfo> {
@@ -36,9 +37,14 @@ export class PackageManager implements INodePackageManager {
 		return this.packageManager.getCachePath();
 	}
 
-	private _determinePackageManager(): INodePackageManager {
-		console.log(`${JSON.stringify(this.$options.yarn)}`);
-		return this.$options.yarn ? this.$yarn : this.$npm;
+	private _determinePackageManager(): void {
+		this.$userSettingsService.getSettingValue('packageManager').then ( (pm: string) => {
+			if (pm === 'yarn' || this.$options.yarn) {
+				this.packageManager = this.$yarn;
+			} else {
+				this.packageManager = this.$npm;
+			}
+		});
 	}
 }
 


### PR DESCRIPTION
By default `tns` will use npm. If you want to use yarn as your default package manager set it using `tns package-manager set yarn`. 